### PR TITLE
[FIX] [interact/client/interacts.lua] Allow arguments

### DIFF
--- a/client/interacts.lua
+++ b/client/interacts.lua
@@ -68,7 +68,7 @@ local function CreateInteractions()
                         elseif option.serverEvent then
                             TriggerServerEvent(option.serverEvent, option.args)
                         elseif option.event then
-                            TriggerEvent(option.event, option)
+                            TriggerEvent(option.event, option.args)
                         end
                     end
                 end


### PR DESCRIPTION
Allow arguments when triggering client events 