### PR TITLE
[QoL] Updates ReadMe and Adjusts Sprite Textures

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,6 +55,9 @@ exports.interact:AddInteraction({
     interactDst = 1.0, -- optional
     id = 'myCoolUniqueId', -- needed for removing interactions
     name = 'interactionName', -- optional
+    groups = {
+        ['police'] = 2, -- Jobname | Job grade
+    }
     options = {
          {
             label = 'Hello World!',
@@ -71,8 +74,35 @@ exports.interact:AddLocalEntityInteraction({
     id = 'myCoolUniqueId', -- needed for removing interactions
     distance = 8.0, -- optional
     interactDst = 1.0, -- optional
+    ignoreLos = false -- optional ignores line of sight
     offset = vec3(0.0, 0.0, 0.0), -- optional
     bone = 'engine', -- optional
+    groups = {
+        ['police'] = 2, -- Jobname | Job grade
+    }
+    options = {
+        {
+            label = 'Hello World!',
+            action = function(entity, coords, args)
+                print(entity, coords, json.encode(args))
+            end,
+        },
+    }
+})
+
+-- Add an interaction point on a networked entity
+exports.interact:AddEntityInteraction({
+    netId = entityNetIdHere,
+    name = 'interactionName', -- optional
+    id = 'myCoolUniqueId', -- needed for removing interactions
+    distance = 8.0, -- optional
+    interactDst = 1.0, -- optional
+    ignoreLos = false -- optional ignores line of sight
+    offset = vec3(0.0, 0.0, 0.0), -- optional
+    bone = 'engine', -- optional
+    groups = {
+        ['police'] = 2, -- Jobname | Job grade
+    }
     options = {
         {
             label = 'Hello World!',
@@ -104,26 +134,6 @@ exports.interact:AddGlobalVehicleInteraction({
 })
 
 
--- Add an interaction point on a networked entity
-exports.interact:AddInteractionEntity({
-    netId = entityNetIdHere,
-    name = 'interactionName', -- optional
-    id = 'myCoolUniqueId', -- needed for removing interactions
-    distance = 8.0, -- optional
-    interactDst = 1.0, -- optional
-    offset = vec3(0.0, 0.0, 0.0), -- optional
-    bone = 'engine', -- optional
-    options = {
-        {
-            label = 'Hello World!',
-            action = function(entity, coords, args)
-                print(entity, coords, json.encode(args))
-            end,
-        },
-    }
-})
-
-
 -- Add interaction(s) to a list of models
 exports.interact:AddModelInteraction({
     model = 'modelName',
@@ -133,6 +143,9 @@ exports.interact:AddModelInteraction({
     id = 'myCoolUniqueId', -- needed for removing interactions
     distance = 8.0, -- optional
     interactDst = 1.0, -- optional
+    groups = {
+        ['police'] = 2, -- Jobname | Job grade
+    }
     options = {
         {
             label = 'Hello World!',

--- a/client/interacts.lua
+++ b/client/interacts.lua
@@ -75,7 +75,7 @@ local function CreateInteractions()
 
             else
                 SetDrawOrigin(coords.x, coords.y, coords.z + 0.05)
-                DrawSprite('interactions_txd', pin, 0, 0, 0.010, 0.02, 0, 255, 255, 255, 255)
+                DrawSprite('interactions_txd', pin, 0, 0, 0.010, 0.025, 0, 255, 255, 255, 255)
             end
 
             ClearDrawOrigin()

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -108,7 +108,7 @@ function utils.drawOption(coords, text, spriteDict, spriteName, row, width, show
     if showDot then
         local newSpritename = spriteName == textures.selected and textures.select_opt or textures.unselect_opt
         SetScriptGfxAlignParams(0.018, row * 0.03 - 0.015, 0.0, 0.0)
-        DrawSprite(spriteDict, newSpritename, 0.0, 0.014, 0.01, 0.02, 0.0, 255, 255, 255, 255)
+        DrawSprite(spriteDict, newSpritename, 0.0, 0.014, 0.011, 0.02, 0.0, 255, 255, 255, 255)
         ResetScriptGfxAlign()
     end
 


### PR DESCRIPTION
ReadMe has the wrong export name and doesn't include groups in all the data. 

Sprite sizes updated for both the pin and select_opt. Tested with all styles.

## Ping Before
![FiveM_b3095_GTAProcess_G78eXI209y](https://github.com/darktrovx/interact/assets/1113196/270adfd3-2bb3-4389-9858-69f3011d5cd2)
## Ping After
![FiveM_b3095_GTAProcess_Wf54uUzEMP](https://github.com/darktrovx/interact/assets/1113196/bd8a3a52-eb1a-42d6-bd51-0bdea203ecb5)
## Option Before
![FiveM_b3095_GTAProcess_DhJfz476Tx](https://github.com/darktrovx/interact/assets/1113196/9c27185a-bf3d-453b-91b8-510678df5f25)
## Option After
![FiveM_b3095_GTAProcess_HTvEZtW1Ir](https://github.com/darktrovx/interact/assets/1113196/cb200a46-4091-4c72-8691-c421b0162352)

