### PR TITLE
Don't call IsControlJustPressed if isClose is false

### DIFF
--- a/client/interacts.lua
+++ b/client/interacts.lua
@@ -78,7 +78,7 @@ local function CreateInteractions()
                         currentSelection += 1
                     end
 
-                    if IsControlJustPressed(0, 38) and isClose then
+                    if isClose and IsControlJustPressed(0, 38) then
                         local option = options[currentSelection]
 
                         if option then


### PR DESCRIPTION
This changes `IsControlJustPressed(0, 38) and isClose` to `isClose and IsControlJustPressed(0, 38)`, which should improve performance a bit. Might not be noticable, but it does prevent calling `IsControlJustPressed` if `isClose` is false.
